### PR TITLE
Small changes to Flatpak support section on quickstart

### DIFF
--- a/src/content/docs/discord-rpc-godot/index.mdx
+++ b/src/content/docs/discord-rpc-godot/index.mdx
@@ -121,8 +121,8 @@ Check that `Discord Settings -> Activity Privacy -> Share your detected activiti
 and restart the editor manually.
 </details>
 <details>
-<summary><b>I downloaded Discord via Flatpack and it doesn't work.</b></summary>
-Just don't use Flatpack... (It doesn't have Discord RPC support at all)
+<summary><b>I downloaded Discord via Flatpak and it doesn't work.</b></summary>
+You can enable Rich Presence support by creating a symlink for a file Discord uses for RPC communication. You can see instructions on how to do that <a href="https://wiki.archlinux.org/title/Discord#Enabling_rich_presence_on_Flatpak">here</a>.
 </details>
 <details>
 <summary><b>I can't get my game working with this plugin on a platform which isn't supported by it.</b></summary>


### PR DESCRIPTION
This small contribution fix a typo for the Flatpak name, which was previously spelled as "Flatpack". It also adds a link to the [Arch Linux Wiki](https://wiki.archlinux.org/title/Discord#Enabling_rich_presence_on_Flatpak) with instructions on how to easily enable Rich Presence on Flatpak versions of Discord.